### PR TITLE
Edit option for Gene Summary + Removed "Edit Database" link

### DIFF
--- a/app/views/genes/index.html.erb
+++ b/app/views/genes/index.html.erb
@@ -4,7 +4,8 @@
     <div class="span12">
       <table class="table table-bordered table-striped">
         <thead>
-          <tr>            
+          <tr>  
+            <th width="2%"></th>          
             <th><%= sortable_col :species, 'Species'%></th>
             <th><%= sortable_col :name, 'Name'%></th>
             <th><%= sortable_col :abbrev, 'Abbrev.'%></th>
@@ -18,6 +19,7 @@
         <tbody>
           <% @genes.each do |gene| %>
             <tr>              
+              <td width="2%"><a class="edit" href="<%= edit_gene_path gene %>"><i class="icon-edit"></i></a></td>
               <td><%= gene.species %></td>
               <td><%= link_to(gene.name, gene) %></td>
               <td><%= gene.abbrev %></td>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,8 +18,7 @@
             <i class="icon-plus-sign icon-white"></i>Database Manipulation
             <b class="caret"></b>
           </a>
-          <ul class="dropdown-menu">
-            <li><a href="">Edit Data</a></li>
+          <ul class="dropdown-menu">            
             <li><a href="#bulk-uploader-modal" data-toggle="modal">Upload Data</a></li>
           </ul>
         </li>


### PR DESCRIPTION
Added the Edit Button row in the gene summary table and hooked up to appropriate view.
Removed the "Edit Database" link from the "Database Manipulation" option on home page.
